### PR TITLE
Sync Workbench configs with rstudio-pro extras/conf upstream

### DIFF
--- a/workbench/audit-database.conf
+++ b/workbench/audit-database.conf
@@ -1,0 +1,46 @@
+# Posit Workbench Audit Database Configuration File
+#
+# Full Configuration Reference: https://docs.posit.co/ide/server-pro/admin/database/audit/configuration.html
+
+#-----------------------------------------------------------------------------------------#
+# Database Provider
+#
+# https://docs.posit.co/ide/server-pro/admin/database/audit/database.html
+# The audit database is an optional feature that stores historical session and usage
+# data separately from the internal database (database.conf). It is disabled by default.
+# When enabled, it defaults to SQLite if no provider is specified. PostgreSQL is required
+# for load-balanced deployments. The audit database must NOT share a database instance
+# with the internal database.
+# This file should be owned by rstudio-server with 600 permissions:
+# chown rstudio-server /etc/rstudio/audit-database.conf
+# chmod 600 /etc/rstudio/audit-database.conf
+# Supported PostgreSQL versions: 13 through 17.
+#-----------------------------------------------------------------------------------------#
+
+#-----------------------------------------------------------------------------------------#
+# PostgreSQL Configuration
+#
+# https://docs.posit.co/ide/server-pro/admin/database/audit/configuration.html#requirements
+# Uncomment and configure the settings below to switch from SQLite to PostgreSQL.
+# The database must be created manually before Workbench connects to it (or set auto-create=1).
+# It is strongly recommended to encrypt the password using: rstudio-server encrypt-password
+#-----------------------------------------------------------------------------------------#
+#provider=postgresql
+#host=localhost # TODO: Update with your PostgreSQL server hostname
+#database=positpwbaudit
+#port=5432
+#username=positpwbuser # TODO: Update with your PostgreSQL username
+#password= # TODO: Update with your encrypted password (use: rstudio-server encrypt-password)
+#auto-create=1
+
+#-----------------------------------------------------------------------------------------#
+# PostgreSQL Connection URI (Alternative)
+#
+# https://docs.posit.co/ide/server-pro/admin/database/audit/configuration.html#ssl-certificate-authentication
+# Use connection-uri instead of individual host/port/database settings for advanced
+# options like SSL certificate authentication. When set, connection-uri overrides
+# host, port, database, and username (but not password).
+#-----------------------------------------------------------------------------------------#
+#provider=postgresql
+#connection-uri=postgresql://positpwbuser@localhost:5432/positpwbaudit?sslmode=verify-full
+#password= # TODO: Update with your encrypted password (use: rstudio-server encrypt-password)

--- a/workbench/database.conf
+++ b/workbench/database.conf
@@ -1,0 +1,40 @@
+# This file contains the internal database configuration.
+#
+# Full Configuration Reference: https://docs.posit.co/ide/server-pro/admin/database/configuration.html
+
+#-----------------------------------------------------------------------------------------#
+# Database Provider
+#
+# SQLite is used by default (no configuration required). An empty file or the
+# absence of this file will use an internal SQLite database. PostgreSQL is required for
+# load-balanced (multi-node) deployments.
+# Supported PostgreSQL versions: 13 through 17.
+#-----------------------------------------------------------------------------------------#
+
+#-----------------------------------------------------------------------------------------#
+# PostgreSQL Configuration
+#
+# https://docs.posit.co/ide/server-pro/admin/database/configuration.html#postgresql
+# Uncomment and configure the settings below to switch from SQLite to PostgreSQL.
+# The database must be created manually before the server connects to it.
+# It is strongly recommended to encrypt the password using: rstudio-server encrypt-password
+# Set this file to 600 permissions: chmod 600 /etc/rstudio/database.conf
+#-----------------------------------------------------------------------------------------#
+#provider=postgresql
+#host=localhost
+#database=posit
+#port=5432
+#username=posit
+#password=
+
+#-----------------------------------------------------------------------------------------#
+# PostgreSQL Connection URI (Alternative)
+#
+# https://docs.posit.co/ide/server-pro/admin/database/configuration.html#ssl-certificate-authentication
+# Use connection-uri instead of individual host/port/database settings for advanced
+# options like SSL certificate authentication. When set, connection-uri overrides
+# host, port, database, and username (but not password).
+#-----------------------------------------------------------------------------------------#
+#provider=postgresql
+#connection-uri=postgresql://posit@localhost:5432/posit?sslmode=verify-full
+#password=

--- a/workbench/jupyter.conf
+++ b/workbench/jupyter.conf
@@ -3,16 +3,18 @@
 # Full Configuration Reference: https://docs.posit.co/ide/server-pro/admin/jupyter_sessions/configuration.html
 
 #-----------------------------------------------------------------------------------------#
-# Jupyter Lab Configuration
+# JupyterLab Configuration
 #
 # https://docs.posit.co/ide/server-pro/admin/jupyter_sessions/configuration.html
-# Enable Jupyter Lab sessions in Workbench. Requires Jupyter to be installed on the system
+# Enable JupyterLab sessions in Workbench. Requires Jupyter to be installed on the system
 # or in a location accessible by the jupyter-exe path. labs-enabled controls whether Jupyter
 # sessions are available to users. default-session-cluster specifies which Job Launcher
 # cluster to use for Jupyter sessions (typically "Local" for local execution or a Kubernetes/
 # Slurm cluster name for distributed execution).
 #-----------------------------------------------------------------------------------------#
-jupyter-exe=/opt/python/{{ REPLACEME }}/bin/python
+
+#jupyter-exe=/opt/python/3.XX.XX/bin/jupyter # TODO: Update with your latest installed
+                                             # version of Python with Jupyter installed
 labs-enabled=1
 default-session-cluster=Local
 
@@ -20,7 +22,10 @@ default-session-cluster=Local
 # Session Timeout Configuration
 #
 # https://docs.posit.co/ide/server-pro/admin/jupyter_sessions/configuration.html
-# session-cull-minutes controls automatic termination of idle Jupyter sessions.
-# Default is 240 minutes (4 hours). Set to 0 to disable automatic culling.
+# session-cull-minutes controls when idle Jupyter kernels are culled.
+# session-shutdown-minutes controls how long after kernels are culled the Jupyter
+# session itself is shut down. Together they bound total idle time before an
+# unjoined or idle session terminates (here, 6h + 2h = 8h).
 #-----------------------------------------------------------------------------------------#
-session-cull-minutes=240
+session-cull-minutes=360
+session-shutdown-minutes=120

--- a/workbench/launcher-env
+++ b/workbench/launcher-env
@@ -1,14 +1,41 @@
-#Launcher Environment Configuration
-#https://docs.posit.co/ide/server-pro/job_launcher/configuration.html#launcher-environment
+# Posit Workbench Launcher Environment Configuration File
+#
+# Full Configuration Reference: https://docs.posit.co/ide/server-pro/admin/job_launcher/configuration.html#launcher-env-conf
 
-JobType: any
-Workbench: any
+# TODO: Uncomment ONE of the following blocks to match your Linux distribution.
+# This ensures Python's requests library trusts the system certificate store,
+# which is required in self-signed certificate environments.
 
-# RHEL Environment setting to make Python use the system certificate store
-# {{ REPLACEME }}
-#Environment: REQUESTS_CA_BUNDLE=/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
+# RHEL / CentOS / Fedora
+# JobType: any
+# Workbench: any
+# Environment: REQUESTS_CA_BUNDLE=/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
 
+# Ubuntu / Debian
+# JobType: any
+# Workbench: any
+# Environment: REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
 
-# Ubuntu/Deb Environment setting to make Python use the system certificate store
-# {{ REPLACEME }}
-#Environment: REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
+#-----------------------------------------------------------------------------------------#
+# VS Code / Positron Extension Gallery (Package Manager)
+#
+# https://docs.posit.co/rspm/admin/workbench.html#vsx-extensions
+# Point VS Code and Positron sessions to a custom extensions gallery hosted by Posit
+# Package Manager instead of the default open-vsx.org. Requires Package Manager to be
+# served over HTTPS with a valid (CA-signed) TLS certificate. The VSX repository must
+# NOT use --authenticated; use network-level controls for access restriction instead.
+#-----------------------------------------------------------------------------------------#
+# JobType: session
+# Workbench: any
+# Environment: EXTENSIONS_GALLERY={"serviceUrl":"https://packagemanager.example.com/openvsx/latest/vscode/gallery","itemUrl":"https://packagemanager.example.com/openvsx/latest/vscode/item"}
+
+#-----------------------------------------------------------------------------------------#
+# Node.js CA Certificates (for self-signed TLS with Package Manager)
+#
+# https://docs.posit.co/rspm/admin/workbench.html#vsx-extensions
+# If Package Manager uses a self-signed certificate, VS Code / Positron need this set
+# so Node.js trusts the internal CA when fetching extensions from the gallery.
+#-----------------------------------------------------------------------------------------#
+# JobType: session
+# Workbench: any
+# Environment: NODE_EXTRA_CA_CERTS=/etc/ssl/certs/my-internal-ca.pem

--- a/workbench/launcher.conf
+++ b/workbench/launcher.conf
@@ -10,39 +10,39 @@
 # Server Configuration
 #
 # https://docs.posit.co/ide/server-pro/admin/job_launcher/configuration.html#server-options
-# Core Job Launcher server settings including network binding, user/group configuration,
-# and logging options. The address and port must match the launcher configuration in
-# rserver.conf (launcher-address and launcher-port).
+# Core Job Launcher server settings including UDS socket path, user/group configuration,
+# and logging options. The address must match the launcher-address in rserver.conf.
 #-----------------------------------------------------------------------------------------#
 [server]
-address=127.0.0.1
-port=5559
+address=/var/run/rstudio-server/rserver-launcher.socket
 
-# User and group the launcher runs as (defaults to rstudio-server)
-;server-user=rstudio-server
-;admin-group=rstudio-server
+# The server-user configured here must match the server-user configured in rserver.conf.
+server-user=rstudio-server
 
-# Enable authorization checks (recommended for production)
-;authorization-enabled=1
+# The admin group configured here must be the primary group of the server-user configured above.
+admin-group=rstudio-server
 
-# Enable debug logging for troubleshooting
-;enable-debug-logging=1
+# Enable cgroups v2 resource limits for local launcher sessions (CPU, memory)
+# Requires cgroups v2 enabled on the host OS. Per-user/group limits are configured
+# in launcher.local.profiles.conf.
+# https://docs.posit.co/ide/server-pro/admin/job_launcher/local_plugin.html#cgroups-resource-limits
+enable-cgroups=1
 
 # Paths for launcher data and logs
-;scratch-path=/var/lib/rstudio-launcher
-;logging-dir=/var/log/rstudio/launcher
+#scratch-path=/var/lib/rstudio-launcher
+#logging-dir=/var/log/rstudio/launcher
 
 #-----------------------------------------------------------------------------------------#
 # Launcher Encryption Configuration
 #
 # https://docs.posit.co/ide/server-pro/admin/job_launcher/configuration.html#ssl-considerations
-# End-to-end encryption settings for launcher. Not required in most cases unless there is
-# a requirement for encryption between Workbench and the launcher (e.g., when launcher
-# runs on a separate host or in security-sensitive environments).
+# End-to-end encryption settings for launcher. Not required when using UDS (default
+# since 2026.04). Only needed for multi-node deployments where launcher communicates
+# over TCP (e.g., when launcher runs on a separate host).
 #-----------------------------------------------------------------------------------------#
-;enable-ssl=0
-;certificate-file=/path/to/certificate_chain
-;certificate-key-file=/path/to/private_key
+#enable-ssl=0
+#certificate-file=/path/to/certificate_chain # TODO: Update with the path to your SSL certificate
+#certificate-key-file=/path/to/private_key # TODO: Update with the path to your SSL private key
 
 #-----------------------------------------------------------------------------------------#
 # Cluster Configuration - Local Execution

--- a/workbench/logging.conf
+++ b/workbench/logging.conf
@@ -1,0 +1,56 @@
+# Posit Workbench Logging Configuration File
+#
+# Full Configuration Reference: https://docs.posit.co/ide/server-pro/admin/server_management/logging.html
+
+#-----------------------------------------------------------------------------------------#
+# Global Logging Defaults
+#
+# https://docs.posit.co/ide/server-pro/admin/server_management/logging.html#configuration-example
+# The [*] section sets defaults inherited by all Workbench executables.
+# Per-executable overrides use [@executable-name] sections.
+# Available executables: rserver, rstudio-launcher, rstudio-local-launcher,
+# rstudio-kubernetes-launcher, rstudio-slurm-launcher
+#-----------------------------------------------------------------------------------------#
+[*]
+log-level=warn
+logger-type=file
+
+#-----------------------------------------------------------------------------------------#
+# Workbench Server (rserver) Logging
+#
+# https://docs.posit.co/ide/server-pro/admin/server_management/logging.html
+# Uncomment to enable debug logging for the rserver process.
+#-----------------------------------------------------------------------------------------#
+#[@rserver]
+#log-level=debug
+#logger-type=file
+#log-dir=/var/log/rstudio/rstudio-server
+#max-size-mb=4
+#rotate-days=1
+#max-rotations=100
+#delete-days=30
+#warn-syslog=1
+
+#-----------------------------------------------------------------------------------------#
+# Launcher Debug Logging
+#
+# https://docs.posit.co/ide/server-pro/admin/job_launcher/troubleshooting/log-files.html
+# Uncomment to enable debug logging for the Job Launcher. This produces verbose output
+# useful for troubleshooting session launch failures. Disable after troubleshooting
+# as it reduces performance and generates significant log data.
+#-----------------------------------------------------------------------------------------#
+#[@rstudio-launcher]
+#log-level=debug
+#logger-type=file
+#log-dir=/var/log/rstudio/launcher
+#rotate-days=2
+#delete-days=10
+
+#-----------------------------------------------------------------------------------------#
+# File Locking Debug Logging
+#
+# https://docs.posit.co/ide/server-pro/admin/server_management/logging.html
+# Uncomment to debug file locking issues (e.g., shared storage problems in HA setups).
+#-----------------------------------------------------------------------------------------#
+#[file-locking]
+#log-level=debug

--- a/workbench/notifications.conf
+++ b/workbench/notifications.conf
@@ -1,0 +1,36 @@
+# Posit Workbench Notifications Configuration File
+#
+# Full Configuration Reference: https://docs.posit.co/ide/server-pro/admin/rstudio_pro_sessions/notifications.html
+
+#-----------------------------------------------------------------------------------------#
+# Notification Entries
+#
+# Broadcast real-time notifications to user sessions as popups (e.g., maintenance windows).
+# Each notification entry consists of three fields: StartTime, EndTime, and Message, each
+# separated by a new line.
+#
+# Each notification MUST be separated by ONE blank line (2 new line characters).
+#
+# StartTime represents when the notification will start to be delivered to sessions. Optional.
+# EndTime represents when the notification will stop being delivered. Required.
+#
+# Time formats:
+#   YYYY-MM-DD                        date only (server timezone, start=00:00:00, end=23:59:59)
+#   YYYY-MM-DD hh:mm                  date and time, seconds default to 00 (server timezone)
+#   YYYY-MM-DD hh:mm:ss tzh:tzm       date, time, and timezone offset (use for multi-node)
+#
+# Message is the text delivered to user sessions as a popup. Blank lines within the message
+# are not supported. To wrap text to a new line, indent the message text on the next line.
+#
+# Modifying an existing notification causes it to be re-delivered to all sessions, so
+# finalize the message before saving.
+#-----------------------------------------------------------------------------------------#
+
+#StartTime: 2018-06-01 10:33:00 -05:00
+#EndTime: 2018-06-05
+#Message: This is a simple notification. Notifications can have multiple lines.
+#    To start a new line, indent the line like so. Blank lines are not supported!
+#
+#StartTime: 2018-07-05 11:00
+#EndTime: 2018-07-05
+#Message: For more information on time and message formatting, see the RSP admin documentation.

--- a/workbench/openid-client-secret
+++ b/workbench/openid-client-secret
@@ -1,7 +1,18 @@
-#-----------------------------------------------------------------------------------------#
-# Authentication - OIDC
+# Posit Workbench OpenID Connect Client Secret File
 #
-# https://docs.posit.co/ide/server-pro/admin/authenticating_users/openid_connect_authentication.html
-# Ensure the file permissions are 600 and run rstudio-server encrypt-password and pass in the client-secret to encrypt it
-client-id={{ REPLACEME }}
-client-secret={{ REPLACEME }}
+# Full Configuration Reference: https://docs.posit.co/ide/server-pro/admin/authenticating_users/openid_connect_authentication.html#configuring-workbench-for-openid-connect
+
+#-----------------------------------------------------------------------------------------#
+# OIDC Client Credentials
+#
+# This file stores the OpenID Connect client-id and client-secret for authentication.
+# File permissions MUST be 600: chmod 600 /etc/rstudio/openid-client-secret
+#
+# It is strongly recommended to encrypt the client-secret:
+#   sudo rstudio-server encrypt-password
+# Then paste the encrypted output as the client-secret value below.
+# Workbench will log a warning if an unencrypted secret is detected.
+#-----------------------------------------------------------------------------------------#
+
+#client-id=your-client-id-here # TODO: Update with your OpenID Connect client ID
+#client-secret=your-encrypted-secret-here # TODO: Update with your encrypted client secret (use: rstudio-server encrypt-password)

--- a/workbench/positron-enforced-settings.json
+++ b/workbench/positron-enforced-settings.json
@@ -1,9 +1,0 @@
-{
-  "_comment": "Positron Enforced Settings - /etc/rstudio/positron-enforced-settings.json",
-  "_documentation": "https://docs.posit.co/ide/server-pro/admin/positron_sessions/user_settings.html#enforced-settings",
-  "_note": "These settings are ENFORCED and users CANNOT override them. Register this file in /etc/rstudio/profiles using 'positron-enforced-settings = /etc/rstudio/positron-enforced-settings.json' under the [*] section. Restart Workbench after changes: sudo rstudio-server restart",
-
-  "extensions.autoUpdate": false,
-  "extensions.autoCheckUpdates": false,
-  "telemetry.telemetryLevel": "off"
-}

--- a/workbench/positron-enforced-settings/default.json
+++ b/workbench/positron-enforced-settings/default.json
@@ -1,0 +1,5 @@
+{
+  "_comment": "Positron Enforced Settings (All Users) - /etc/rstudio/positron-enforced-settings/default.json",
+  "_documentation": "https://docs.posit.co/ide/server-pro/admin/positron_sessions/user_settings.html#enforced-settings",
+  "_note": "These settings are enforced for all users and cannot be overridden. Register this file in /etc/rstudio/profiles under the [*] section using 'positron-enforced-settings = /etc/rstudio/positron-enforced-settings/default.json'. Create additional files in this directory for group-specific or user-specific enforced settings (e.g., data-science.json, jsmith.json). Restart Workbench after changes: sudo rstudio-server restart. Example settings: extensions.autoUpdate, extensions.autoCheckUpdates, telemetry.telemetryLevel"
+}

--- a/workbench/positron-user-settings.json
+++ b/workbench/positron-user-settings.json
@@ -1,7 +1,7 @@
 {
   "_comment": "Positron Default User Settings Template - /etc/rstudio/positron-user-settings.json",
   "_documentation": "https://docs.posit.co/ide/server-pro/admin/positron_sessions/user_settings.html",
-  "_note": "These settings are merged into each user's Positron settings.json on first launch. Users CAN override these after initial merge. For truly enforced settings that users cannot change, use positron-enforced-settings.json and register it in the profiles file.",
+  "_note": "These settings are merged into each user's Positron settings.json on first launch. Users can override these after initial merge. For enforced settings that users cannot change, see: https://docs.posit.co/ide/server-pro/admin/positron_sessions/user_settings.html#enforced-settings",
 
   "terminal.integrated.defaultProfile.linux": "bash",
   "extensions.autoUpdate": false,
@@ -14,9 +14,5 @@
   "python.environmentProviders.enable": {
     "Conda": false
   },
-  "files.autoSave": "afterDelay",
-  "files.autoSaveDelay": 1000,
-  "editor.formatOnSave": true,
-  "editor.tabSize": 2,
-  "workbench.colorTheme": "Default Dark+"
+  "window.autoDetectColorScheme": true
 }

--- a/workbench/positron.conf
+++ b/workbench/positron.conf
@@ -12,14 +12,8 @@
 # sessions (0 = never kill, keep suspended indefinitely).
 #-----------------------------------------------------------------------------------------#
 enabled=1
+user-data-dir=~/.positron-server
+default-session-cluster=Local
 
 # Forcibly terminate suspended sessions after specified hours (0 = never)
-;session-timeout-kill-hours=0
-
-#-----------------------------------------------------------------------------------------#
-# Default Cluster Configuration
-#
-# https://docs.posit.co/ide/server-pro/admin/positron_sessions/configuration.html
-# Specify which Job Launcher cluster to use for Positron sessions.
-#-----------------------------------------------------------------------------------------#
-;default-session-cluster=Local
+session-timeout-kill-hours=8

--- a/workbench/profiles
+++ b/workbench/profiles
@@ -12,7 +12,7 @@
 # After modifying this file, restart Workbench: sudo rstudio-server restart
 #-----------------------------------------------------------------------------------------#
 [*]
-positron-enforced-settings = /etc/rstudio/positron-enforced-settings.json
+positron-enforced-settings = /etc/rstudio/positron-enforced-settings/default.json
 
 #-----------------------------------------------------------------------------------------#
 # Group-Based Enforced Settings (Example)
@@ -20,8 +20,8 @@ positron-enforced-settings = /etc/rstudio/positron-enforced-settings.json
 # https://docs.posit.co/ide/server-pro/admin/positron_sessions/user_settings.html#enforced-settings
 # You can create different enforced settings for specific Unix groups.
 #-----------------------------------------------------------------------------------------#
-;[@data-science]
-;positron-enforced-settings = /etc/rstudio/data-science-enforced-settings.json
+#[@data-science]
+#positron-enforced-settings = /etc/rstudio/positron-enforced-settings/data-science.json
 
 #-----------------------------------------------------------------------------------------#
 # User-Based Enforced Settings (Example)
@@ -29,5 +29,5 @@ positron-enforced-settings = /etc/rstudio/positron-enforced-settings.json
 # https://docs.posit.co/ide/server-pro/admin/positron_sessions/user_settings.html#enforced-settings
 # You can create different enforced settings for specific users.
 #-----------------------------------------------------------------------------------------#
-;[jsmith]
-;positron-enforced-settings = /etc/rstudio/jsmith-enforced-settings.json
+#[jsmith]
+#positron-enforced-settings = /etc/rstudio/positron-enforced-settings/jsmith.json

--- a/workbench/r-versions
+++ b/workbench/r-versions
@@ -1,0 +1,31 @@
+# Posit Workbench R Versions Configuration File
+#
+# Full Configuration Reference: https://docs.posit.co/ide/server-pro/admin/r/using_multiple_versions_of_r.html#extended-r-version-definitions
+
+#-----------------------------------------------------------------------------------------#
+# R Version Entries
+#
+# Manually specify R installations available for sessions. Workbench auto-detects
+# R in standard locations (/opt/R, /usr/local/lib/R), so this file is only needed
+# when R is installed in non-standard paths or you need to set Labels, Modules,
+# Scripts, Repos, or Library paths per version.
+#
+# Available fields: Path (required), Label, Module, Script, Repo, Library
+# Separate entries with exactly one blank line. No blank lines within an entry.
+# Simple path-only entries (no field prefix) are also supported.
+#-----------------------------------------------------------------------------------------#
+
+# Extended entry with label and pre-session script
+#Path: /opt/R/4.4.2
+#Label: R 4.4.2
+#Script: /opt/R/4.4.2/env-setup.sh
+#
+# Entry using an environment module (e.g., Lmod on HPC clusters)
+#Path: /opt/R/4.3.3
+#Label: R 4.3.3
+#Module: r/4.3.3
+#
+# Simple path-only entries (no field prefix needed)
+# /opt/R/4.4.2
+# /opt/R/4.3.3
+# /opt/R/4.2.3

--- a/workbench/repos.conf
+++ b/workbench/repos.conf
@@ -1,6 +1,6 @@
 # Posit Workbench R Package Repository Configuration
 #
-# https://solutions.posit.co/envs-pkgs/rsw_defaults/
+# https://docs.posit.co/rspm/admin/workbench.html
 #
 # This file sets the default R/CRAN repositories for R sessions in Workbench. These settings
 # are applied to all R sessions and override the default CRAN mirror. This is particularly
@@ -16,18 +16,14 @@
 # Supported distributions: centos7, centos8, rhel9, ubuntu18, ubuntu20, ubuntu22, ubuntu24,
 # opensuse15, opensuse42, debian11, debian12
 
-# Posit Public Package Manager (replace {{ REPLACEME }} with your Linux distro/version)
+# Posit Public Package Manager (replace distro-version-here with your Linux distro/version)
 # Examples:
 #   - ubuntu22 for Ubuntu 22.04
 #   - rhel9 for RHEL 9
 #   - centos7 for CentOS 7
-CRAN=https://packagemanager.posit.co/cran/__linux__/{{ REPLACEME }}/latest
+
+#CRAN=https://packagemanager.posit.co/cran/__linux__/distro-version-here/latest # TODO: Replace distro-version-here with your Linux distro/version, eg: ubuntu22
 
 # Internal Package Manager (if you have your own instance)
 # Replace with your internal Package Manager URL
-;CRAN=https://packagemanager.company.com/cran/__linux__/ubuntu22/latest
-
-# Bioconductor repository (optional, for bioinformatics packages)
-;BioCsoft=https://packagemanager.posit.co/bioconductor/__linux__/{{ REPLACEME }}/latest
-;BioCann=https://packagemanager.posit.co/bioconductor/__linux__/{{ REPLACEME }}/latest
-;BioCexp=https://packagemanager.posit.co/bioconductor/__linux__/{{ REPLACEME }}/latest
+#CRAN=https://packagemanager.company.com/cran/__linux__/ubuntu22/latest

--- a/workbench/rserver.conf
+++ b/workbench/rserver.conf
@@ -3,23 +3,6 @@
 # Full Configuration Reference: https://docs.posit.co/ide/server-pro/admin/reference/rserver_conf.html
 
 #-----------------------------------------------------------------------------------------#
-# HTTPS / TLS Configuration
-#
-# https://docs.posit.co/ide/server-pro/admin/access_and_security/secure_sockets.html
-# Configure SSL/TLS for encrypted connections. The certificate key should be owned by
-# the rstudio-server user with permissions 600 (chmod 600). Workbench does not support
-# passphrase-protected SSL certificates. Restrict to modern TLS versions (1.2, 1.3) for
-# security hardening.
-#-----------------------------------------------------------------------------------------#
-ssl-enabled=1
-ssl-certificate=/path/to/certificate/posit.crt
-ssl-certificate-key=/path/to/key/posit.key
-
-# Restrict to modern TLS protocols only (security hardening)
-# https://docs.posit.co/ide/server-pro/admin/access_and_security/secure_sockets.html#restrict-tls-versions
-ssl-protocols=TLSv1.2 TLSv1.3
-
-#-----------------------------------------------------------------------------------------#
 # Launcher Configuration
 #
 # https://docs.posit.co/ide/server-pro/admin/job_launcher/configuration.html#server-options
@@ -28,70 +11,19 @@ ssl-protocols=TLSv1.2 TLSv1.3
 # workloads. launcher-sessions-callback-address must be accessible from compute nodes.
 #-----------------------------------------------------------------------------------------#
 launcher-sessions-enabled=1
-launcher-address=127.0.0.1
-launcher-port=5559
+launcher-address=/var/run/rstudio-server/rserver-launcher.socket
 launcher-default-cluster=Local
-launcher-sessions-callback-address=https://{{ REPLACEME }}/
 
-# Enable SSL for launcher communication (recommended for HA and security)
-# https://docs.posit.co/ide/server-pro/admin/hardening/example_secure_configuration.html
-;launcher-use-ssl=1
 
-#-----------------------------------------------------------------------------------------#
-# Admin Dashboard Configuration
+# The launcher-sessions-callback-address is the address that sessions started through the Launcher
+# use to contact Workbench. For a single-node Workbench installation with the Local Launcher
+# Plugin, and not using SSL (the default configuration), localhost should suffice.
+# If you set the rserver's www-port, or ssl-enabled, you must update this address to match.
 #
-# https://docs.posit.co/ide/server-pro/admin/server_management/administrative_dashboard.html
-# The Admin Dashboard is not enabled by default (accessible at http://<server-address>/admin).
-# admin-superuser-group members can: 1) Suspend or terminate active sessions, 2) Assume
-# control of active sessions (e.g., for troubleshooting), and 3) Login as any server user.
-# admin-monitor-log-use-server-time-zone displays log times in server timezone vs UTC.
-#-----------------------------------------------------------------------------------------#
-admin-enabled=1
-admin-group=posit-admins
-admin-superuser-group=posit-super-admin
-admin-monitor-log-use-server-time-zone=1
-
-#-----------------------------------------------------------------------------------------#
-# Health Check Endpoint
-#
-# https://docs.posit.co/ide/server-pro/admin/auditing_and_monitoring/server_health_checks.html
-# Non-authenticated health check endpoint for monitoring and load balancer health checks.
-# Accessible at http://<server-address-and-port>/health-check when enabled. Returns JSON
-# with system status, license validity, and resource availability.
-#-----------------------------------------------------------------------------------------#
-server-health-check-enabled=1
-
-#-----------------------------------------------------------------------------------------#
-# Authentication - SAML Single Sign-On
-#
-# https://docs.posit.co/ide/server-pro/admin/authenticating_users/saml_sso.html
-# SAML SSO configuration for enterprise identity providers. Post binding is required for
-# many IDPs, most commonly Azure AD. Use auth-saml-metadata-url for internet-connected
-# systems or auth-saml-metadata-path for air-gapped deployments.
-#-----------------------------------------------------------------------------------------#
-;auth-saml=1
-;auth-saml-sp-attribute-username=NameID
-
-# Post binding is required for many customer IDPs, most commonly for Azure
-;auth-saml-idp-post-binding=1
-
-# For Workbench instances with outbound internet access to the IDP
-;auth-saml-metadata-url={{ REPLACEME }}
-
-# For Workbench instances restricted from outbound connections to the IDP
-;auth-saml-metadata-path=/etc/rstudio/metadata.xml
-
-#-----------------------------------------------------------------------------------------#
-# Authentication - OpenID Connect (OIDC)
-#
-# https://docs.posit.co/ide/server-pro/admin/authenticating_users/openid_connect_authentication.html
-# OpenID Connect authentication for modern OAuth 2.0 identity providers. Requires
-# auth-openid-issuer to be set to the IdP's discovery endpoint. The username claim
-# (e.g., preferred_username, email) must be specified and match the IdP's token format.
-#-----------------------------------------------------------------------------------------#
-auth-openid=1
-auth-openid-issuer={{ REPLACEME }}
-auth-openid-username-claim=preferred_username
+# For more information about configuring this correctly in more complex environments, see this
+# section of the admin guide:
+# https://docs.rstudio.com/ide/server-pro/job_launcher/configuration.html
+launcher-sessions-callback-address=http://localhost:8787
 
 #-----------------------------------------------------------------------------------------#
 # PAM Session Configuration
@@ -103,35 +35,24 @@ auth-openid-username-claim=preferred_username
 # auth-pam-sessions-use-password to forward credentials to the session.
 #-----------------------------------------------------------------------------------------#
 auth-pam-sessions-enabled=1
-auth-pam-sessions-profile=rstudio
+auth-pam-sessions-profile=su
 
 # Forward PAM credentials to sessions (required for Kerberos, pam_mount)
-;auth-pam-sessions-use-password=1
+#auth-pam-sessions-use-password=1
 
 #-----------------------------------------------------------------------------------------#
-# Auditing Configuration
+# Admin Dashboard Configuration
 #
-# https://docs.posit.co/ide/server-pro/admin/auditing_and_monitoring/auditing_configuration.html
-# Comprehensive auditing of R sessions and console activity. R session auditing logs
-# session start/stop/suspend events. R console auditing can log all commands (input) or
-# all commands and output (all). JSON format is recommended for structured log processing.
-# Logs are stored in audit-data-path with automatic rotation and retention limits.
+# https://docs.posit.co/ide/server-pro/admin/server_management/administrative_dashboard.html
+# The Admin Dashboard is accessible at http://<server-address>/admin.
+# admin-superuser-group members can: 1) Suspend or terminate active sessions, 2) Assume
+# control of active sessions (e.g., for troubleshooting), and 3) Login as any server user.
+# admin-monitor-log-use-server-time-zone displays log times in server timezone vs UTC.
 #-----------------------------------------------------------------------------------------#
-
-# General audit settings
-audit-data-path=/var/lib/rstudio-server/audit/
-
-# R Session auditing (session lifecycle events)
-audit-r-sessions=1
-audit-r-sessions-format=json
-audit-r-sessions-limit-mb=2048
-audit-r-sessions-limit-months=13
-
-# R Console auditing (command and output logging)
-# Options: "input" (commands only) or "all" (commands and output)
-;audit-r-console=all
-;audit-r-console-format=json
-;audit-r-console-user-limit-mb=100
+admin-enabled=1
+admin-group=posit-admins # TODO: Create this group or update to match an existing group on this system
+admin-superuser-group=posit-super-admin # TODO: Create this group or update to match an existing group on this system
+admin-monitor-log-use-server-time-zone=1
 
 #-----------------------------------------------------------------------------------------#
 # Python Package Index Configuration
@@ -140,25 +61,103 @@ audit-r-sessions-limit-months=13
 # Configure the default Python package index (PyPI repository) for Workbench sessions.
 # This value is injected into sessions as PIP_INDEX_URL and UV_INDEX_URL, so both pip
 # and uv use this repository by default. Useful for pointing to internal Package Manager
-# instances or Posit Public Package Manager for faster binary package installations.
+# instances or Posit Public Package Manager.
 #-----------------------------------------------------------------------------------------#
-;session-python-index-url=https://packagemanager.posit.co/pypi/latest/simple
+session-python-index-url=https://packagemanager.posit.co/pypi/latest/simple
 
-# Internal Package Manager (if you have your own instance)
-;session-python-index-url=https://packagemanager.company.com/pypi/latest/simple
+#-----------------------------------------------------------------------------------------#
+# HTTPS / TLS Configuration
+#
+# https://docs.posit.co/ide/server-pro/admin/access_and_security/secure_sockets.html
+# Configure SSL/TLS for encrypted connections. The certificate key should be owned by
+# the rstudio-server user with permissions 600 (chmod 600). Workbench does not support
+# passphrase-protected SSL certificates. Restrict to modern TLS versions (1.2, 1.3) for
+# security hardening.
+#-----------------------------------------------------------------------------------------#
+#ssl-enabled=1
+#ssl-certificate=/path/to/certificate/posit.crt # TODO: Update with the path to your SSL certificate
+#ssl-certificate-key=/path/to/key/posit.key # TODO: Update with the path to your SSL private key
+
+# Restrict to modern TLS protocols only (security hardening)
+# https://docs.posit.co/ide/server-pro/admin/access_and_security/secure_sockets.html#restrict-tls-versions
+#ssl-protocols=TLSv1.2 TLSv1.3
+
+# Enable SSL for launcher communication (only needed for HA/multi-node where launcher
+# communicates over TCP rather than UDS)
+# https://docs.posit.co/ide/server-pro/admin/hardening/example_secure_configuration.html
+#launcher-use-ssl=1
+
+#-----------------------------------------------------------------------------------------#
+# Authentication - SAML Single Sign-On
+#
+# https://docs.posit.co/ide/server-pro/admin/authenticating_users/saml_sso.html
+# SAML SSO configuration for enterprise identity providers. Post binding is required for
+# many IDPs, most commonly Azure AD. Use auth-saml-metadata-url for internet-connected
+# systems or auth-saml-metadata-path for air-gapped deployments.
+#-----------------------------------------------------------------------------------------#
+#auth-saml=1
+#auth-saml-sp-attribute-username=NameID
+
+# Post binding is required for many customer IDPs, most commonly for Azure
+#auth-saml-idp-post-binding=1
+
+# For Workbench instances with outbound internet access to the IDP
+#auth-saml-metadata-url=https://idp.your-domain.com/saml/metadata # TODO: Update with your SAML IdP metadata URL
+
+# For Workbench instances restricted from outbound connections to the IDP
+#auth-saml-metadata-path=/etc/rstudio/metadata.xml
+
+#-----------------------------------------------------------------------------------------#
+# Authentication - OpenID Connect (OIDC)
+#
+# https://docs.posit.co/ide/server-pro/admin/authenticating_users/openid_connect_authentication.html
+# OpenID Connect authentication for modern OAuth 2.0 identity providers. Requires
+# auth-openid-issuer to be set to the IdP's discovery endpoint. The username claim
+# (e.g., preferred_username, email) must be specified and match the IdP's token format.
+#-----------------------------------------------------------------------------------------#
+#auth-openid=1
+#auth-openid-issuer=https://idp.your-domain.com # TODO: Update with your OpenID Connect issuer URL
+#auth-openid-username-claim=preferred_username
+
+#-----------------------------------------------------------------------------------------#
+# User Provisioning - JIT (Just-In-Time)
+#
+# https://docs.posit.co/ide/server-pro/admin/user_provisioning/just_in_time_provisioning.html
+# Automatically creates local user accounts on first successful SSO login. Requires SSO
+# (SAML or OIDC) to be configured above and a mechanism for creating home directories
+# (e.g., pam_mkhomedir in the PAM profile). JIT does not support user deactivation or
+# lifecycle management — use SCIM provisioning below if you need those capabilities.
+#-----------------------------------------------------------------------------------------#
+#user-provisioning-enabled=1
+#user-provisioning-register-on-first-login=1
+#user-provisioning-start-uid=2000
+#group-provisioning-start-gid=2000
+
+#-----------------------------------------------------------------------------------------#
+# User Provisioning - SCIM
+#
+# https://docs.posit.co/ide/server-pro/admin/user_provisioning/user_provisioning.html
+# SCIM enables full user lifecycle management (create, update, deactivate) driven by your
+# IdP. Requires HTTPS with a CA-signed certificate. After enabling, generate a bearer
+# token with: sudo rstudio-server user-service generate-token "My Token"
+# Then configure your IdP to point to https://<workbench-hostname>/scim/v2
+# https://docs.posit.co/ide/server-pro/admin/user_provisioning/okta.html (Okta)
+# https://docs.posit.co/ide/server-pro/admin/user_provisioning/azure.html (Entra ID)
+#-----------------------------------------------------------------------------------------#
+#user-provisioning-enabled=1
 
 #-----------------------------------------------------------------------------------------#
 # Session Diagnostics
 #
-# https://docs.posit.co/ide/server-pro/admin/reference/rserver_conf.html#rsession-settings
-# Session diagnostics collect detailed debugging information for troubleshooting session
-# startup issues. rsession-diagnostics-strace-enabled adds system call tracing (strace)
-# for deep debugging. Enable these temporarily when troubleshooting, as they generate
-# significant log data.
+# https://docs.posit.co/ide/server-pro/admin/rstudio_pro_sessions/r_executable_and_libraries.html#enabling-session-diagnostics-for-individual-sessions
+# Per-user session diagnostics are preferred over global diagnostics, as they generate
+# far less data on disk. Enable per-user diagnostics for individual users experiencing
+# issues, rather than enabling globally here.
+# Global diagnostics (below) should only be used when all users are affected.
 #-----------------------------------------------------------------------------------------#
-;rsession-diagnostics-dir=/var/log/rstudio
-;rsession-diagnostics-enabled=1
-;rsession-diagnostics-strace-enabled=1
+#rsession-diagnostics-dir=/var/log/rstudio
+#rsession-diagnostics-enabled=1
+#rsession-diagnostics-strace-enabled=1
 
 #-----------------------------------------------------------------------------------------#
 # Security Hardening Settings
@@ -170,29 +169,30 @@ audit-r-sessions-limit-months=13
 # your Workbench domain.
 #-----------------------------------------------------------------------------------------#
 
-# Limit access to specific Unix group membership (recommended)
-;auth-required-user-group=posit-users
+# Limit access to specific Unix group membership
+#auth-required-user-group=posit-users
 
-# Shorter idle timeout (default is 60 minutes, 20 minutes is more secure)
-;auth-timeout-minutes=20
+# Minutes of no browser interaction (no clicks, keystrokes, or API calls) before
+# the user's auth session expires and they must re-login. Default is 60 minutes.
+#auth-timeout-minutes=20
 
 # HTTP Strict Transport Security (HSTS) settings for 1 year with subdomains
 # https://docs.posit.co/ide/server-pro/admin/access_and_security/secure_sockets.html#use-http-strict-transport-security-hsts
-;ssl-hsts-max-age=31536000
-;ssl-hsts-include-subdomains=1
+#ssl-hsts-max-age=31536000
+#ssl-hsts-include-subdomains=1
 
 # Enable origin checks on all HTTP requests (CSRF defense)
 # https://docs.posit.co/ide/server-pro/admin/hardening/browser_security.html
-;www-enable-origin-check=1
+#www-enable-origin-check=1
 
 # Ensure the domain on which Workbench is hosted is permitted as an origin
-;www-allow-origin=mysubdomain.mydomain.com
+#www-allow-origin=mysubdomain.mydomain.com
 
 # Set SameSite attribute on all cookies (lax or strict)
-;www-same-site=lax
+#www-same-site=lax
 
-# Prevent embedding Workbench in iframes on other pages (clickjacking defense)
-;www-frame-origin=none
+# Prevent embedding Workbench in iframes on other pages
+#www-frame-origin=none
 
 #-----------------------------------------------------------------------------------------#
 # Load Balancing / High Availability Configuration
@@ -205,23 +205,44 @@ audit-r-sessions-limit-months=13
 #-----------------------------------------------------------------------------------------#
 
 # Enable load balancing for multi-node deployments
-;load-balancing-enabled=1
+load-balancing-enabled=0
+
+#---------------------ENHANCED----------------------#
 
 #-----------------------------------------------------------------------------------------#
-# Network Binding Configuration
+# Health Check Endpoint
 #
-# https://docs.posit.co/ide/server-pro/admin/access_and_security/running_with_a_proxy.html
-# Network interface and port binding. For single-server behind a local proxy, bind to
-# localhost (127.0.0.1). For load-balanced or externally accessible servers, bind to
-# 0.0.0.0 or a specific IP. Leave www-port empty to use default (443 if SSL enabled,
-# 8787 otherwise).
+# https://docs.posit.co/ide/server-pro/admin/auditing_and_monitoring/server_health_checks.html
+# Non-authenticated health check endpoint for monitoring and load balancer health checks.
+# Accessible at http://<server-address-and-port>/health-check when enabled. Returns JSON
+# with system status, license validity, and resource availability.
+# NOTE: This should be defaulted on and not tier-locked.
+#-----------------------------------------------------------------------------------------#
+#server-health-check-enabled=1
+
+#-----------------------------------------------------------------------------------------#
+# Auditing Configuration
+#
+# https://docs.posit.co/ide/server-pro/admin/auditing_and_monitoring/auditing_configuration.html
+# Comprehensive auditing of R sessions and console activity. R session auditing logs
+# session start/stop/suspend events. R console auditing can log all commands (input) or
+# all commands and output (all). JSON format is recommended for structured log processing.
+# Logs are stored in audit-data-path with automatic rotation and retention limits.
 #-----------------------------------------------------------------------------------------#
 
-# Bind to all interfaces (required for load balancing or external access)
-;www-address=0.0.0.0
+# General audit settings
+#audit-data-path=/var/lib/rstudio-server/audit/
 
-# Bind to localhost only (for single-server behind local proxy)
-;www-address=127.0.0.1
+# R Session auditing (session lifecycle events)
+#audit-r-sessions=1
+#audit-r-sessions-format=json
+#audit-r-sessions-limit-mb=2048
+#audit-r-sessions-limit-months=13
 
-# Port binding (leave empty for default: 443 with SSL, 8787 without)
-;www-port=
+# R Console auditing (command and output logging)
+# Options: "input" (commands only) or "all" (commands and output)
+#audit-r-console=all
+#audit-r-console-format=json
+#audit-r-console-user-limit-mb=100
+
+#------------------END - ENHANCED-------------------#

--- a/workbench/rsession.conf
+++ b/workbench/rsession.conf
@@ -7,24 +7,11 @@
 #
 # https://docs.posit.co/ide/server-pro/admin/reference/rsession_conf.html#rsession-settings
 # Controls automatic session termination. session-timeout-minutes suspends inactive
-# sessions (default: 120 minutes). session-timeout-kill-hours forcibly terminates
-# suspended sessions after the specified time (0 = never kill, keep suspended indefinitely).
+# sessions. session-timeout-kill-hours forcibly terminates
+# sessions after the specified time (0 = never kill, keep running indefinitely).
 #-----------------------------------------------------------------------------------------#
-session-timeout-minutes=120
+session-timeout-minutes=480
 session-timeout-kill-hours=0
-
-#-----------------------------------------------------------------------------------------#
-# Session Defaults and User Experience
-#
-# https://docs.posit.co/ide/server-pro/admin/reference/rsession_conf.html#rsession-settings
-# Default locations and templates for new R sessions. session-default-new-project-dir sets
-# the default directory when users create new projects. session-first-project-template-path
-# can point to a template project that will be copied for first-time users.
-#-----------------------------------------------------------------------------------------#
-session-default-new-project-dir=~/projects
-
-# Template project for new users (optional)
-;session-first-project-template-path=/opt/templates/default-project
 
 #-----------------------------------------------------------------------------------------#
 # Posit Connect Integration
@@ -34,7 +21,7 @@ session-default-new-project-dir=~/projects
 # single-product server deployments if users will configure their own Connect servers,
 # but simplifies publishing workflows by pre-configuring the target Connect URL.
 #-----------------------------------------------------------------------------------------#
-default-rsconnect-server={{ REPLACEME }}
+#default-rsconnect-server=https://connect.your-domain.com # TODO: Update with your Posit Connect server URL
 
 #-----------------------------------------------------------------------------------------#
 # Package Repository Configuration
@@ -44,7 +31,7 @@ default-rsconnect-server={{ REPLACEME }}
 # When set to 0, users can still change repositories from the R console but not
 # through the GUI. Use this to enforce use of Package Manager or internal mirrors.
 #-----------------------------------------------------------------------------------------#
-;allow-r-cran-repos-edit=0
+#allow-r-cran-repos-edit=0
 
 #-----------------------------------------------------------------------------------------#
 # Security Hardening Settings
@@ -53,22 +40,12 @@ default-rsconnect-server={{ REPLACEME }}
 # Security options to restrict user capabilities and reduce attack surface.
 #-----------------------------------------------------------------------------------------#
 
-# Disable publishing to external services (RPubs, shinyapps.io)
+# Disable publishing to external services (RPubs, Posit Connect Cloud)
 # https://docs.posit.co/ide/server-pro/admin/reference/rsession_conf.html#rsconnect-settings
-;allow-external-publish=0
+#allow-external-publish=0
 
 # Restrict directory view to prevent exploration of system directories
 # When enabled, users cannot browse directories outside their home directory and
 # shared project directories
 # https://docs.posit.co/ide/server-pro/admin/reference/rsession_conf.html#rsession-settings
-;restrict-directory-view=1
-
-#-----------------------------------------------------------------------------------------#
-# R Version and Package Settings
-#
-# https://docs.posit.co/ide/server-pro/admin/reference/rsession_conf.html#r-settings
-# R interpreter settings and package management options.
-#-----------------------------------------------------------------------------------------#
-
-# R library paths (colon-separated, like standard R_LIBS)
-;r-libs-user=~/R/library
+#restrict-directory-view=1

--- a/workbench/vscode-user-settings.json
+++ b/workbench/vscode-user-settings.json
@@ -1,15 +1,11 @@
 {
   "_comment": "VS Code Default User Settings Template - /etc/rstudio/vscode-user-settings.json",
   "_documentation": "https://docs.posit.co/ide/server-pro/admin/vscode_sessions/user_settings.html",
-  "_note": "These settings are merged into each user's VS Code settings.json on first launch. Users CAN override these after initial merge. For truly enforced settings, use OS-level controls (not available via Workbench configuration). See positron-enforced-settings.json for Positron's enforced settings capability.",
+  "_note": "These settings are merged into each user's VS Code settings.json on first launch. Users can override these after initial merge. For enforced settings, use OS-level controls (not available via Workbench configuration). See positron-enforced-settings.json for Positron's enforced settings capability.",
 
-  "terminal.integrated.defaultProfile.linux": "bash",
+  "terminal.integrated.defaultProfile.linux": "/bin/bash",
   "extensions.autoUpdate": false,
   "extensions.autoCheckUpdates": false,
   "quarto.path": "/usr/lib/rstudio-server/bin/quarto/bin/quarto",
-  "files.autoSave": "afterDelay",
-  "files.autoSaveDelay": 1000,
-  "editor.formatOnSave": true,
-  "editor.tabSize": 2,
-  "workbench.colorTheme": "Default Dark+"
+  "window.autoDetectColorScheme": true
 }

--- a/workbench/vscode.conf
+++ b/workbench/vscode.conf
@@ -13,30 +13,15 @@
 #-----------------------------------------------------------------------------------------#
 exe=/usr/lib/rstudio-server/bin/pwb-code-server/bin/code-server
 enabled=1
-args=--host=0.0.0.0
 user-data-dir=~/.vscode-server
+default-session-cluster=Local
 
 #-----------------------------------------------------------------------------------------#
 # Session Timeout Configuration
 #
-# https://docs.posit.co/ide/server-pro/admin/vscode_sessions/configuration.html
-# session-cull-minutes controls automatic termination of idle VS Code sessions.
-# Default is 240 minutes (4 hours). Set to 0 to disable automatic culling.
+# https://docs.posit.co/ide/server-pro/admin/vscode_sessions/configuration.html#idle-session-timeout
+# session-timeout-kill-hours controls forcible termination of idle VS Code sessions.
+# VS Code sessions are killed (not suspended), so ensure Auto Save and Hot Exit are
+# enabled in user settings. Minimum recommended value is 2 hours. 0 = never kill.
 #-----------------------------------------------------------------------------------------#
-session-cull-minutes=240
-
-#-----------------------------------------------------------------------------------------#
-# Default Cluster Configuration
-#
-# https://docs.posit.co/ide/server-pro/admin/vscode_sessions/configuration.html
-# Specify which Job Launcher cluster to use for VS Code sessions.
-#-----------------------------------------------------------------------------------------#
-default-session-cluster=Local
-
-#-----------------------------------------------------------------------------------------#
-# Container Image Configuration (for containerized deployments)
-#
-# https://docs.posit.co/ide/server-pro/admin/vscode_sessions/configuration.html
-# Specify default container image for VS Code sessions when using Kubernetes or Docker.
-#-----------------------------------------------------------------------------------------#
-;default-session-container-image=rstudio:vscode-session
+session-timeout-kill-hours=8

--- a/workbench/vscode.extensions.conf
+++ b/workbench/vscode.extensions.conf
@@ -1,0 +1,36 @@
+# Posit Workbench VS Code Extensions Configuration File
+#
+# Full Configuration Reference: https://docs.posit.co/ide/server-pro/admin/vscode_sessions/extension_configuration.html
+
+#-----------------------------------------------------------------------------------------#
+# Extension List
+#
+# If VS Code sessions have not been configured, this file will be ignored.
+#
+# Add entries to this file to specify VS Code extensions to be installed by Posit Workbench
+# for all users. Each line should contain exactly one extension. Lines starting with # are
+# ignored. VS Code extensions can be installed from https://open-vsx.org/ or a local file.
+#
+# To include an extension from open-vsx.org, retrieve the extension ID including the
+# publisher from the website and provide it in this file. Optionally, you can provide a
+# version or any other arguments accepted by code-server's install-extension command.
+#
+# The following examples can be uncommented to be used:
+#
+# REditorSupport.r@2.6.1
+# ms-python.python
+#
+# To force a specific extension to be re-installed you can supply the --force parameter:
+#
+# quarto.quarto --force
+#
+# To include an extension from a local .vsix file, provide the path to the extension file:
+# /opt/code-server/extension-dir/extension-name-1.0.0.vsix
+#
+# If configuring VS Code with a global extensions directory (by setting extensions-dir in
+# vscode.conf), you must run `rstudio-server install-vs-code-ext` to install these extensions.
+#-----------------------------------------------------------------------------------------#
+
+quarto.quarto
+posit.shiny
+posit.publisher


### PR DESCRIPTION
## Summary

Syncs the `workbench/` configuration defaults with the canonical opinionated configs maintained in [`rstudio/rstudio-pro` `src/cpp/server/extras/conf`](https://github.com/rstudio/rstudio-pro/tree/main/src/cpp/server/extras/conf). All updated files now match upstream byte-for-byte.

## Changes

**Updated existing files** to upstream content:
- `rserver.conf` — UDS launcher socket, PAM sessions, JIT/SCIM user provisioning, `session-python-index-url`, reorganized SSL/auth/audit sections, `# TODO:` annotations
- `rsession.conf` — longer default `session-timeout-minutes` (480), per-user diagnostics guidance
- `launcher.conf` / `launcher-env` — UDS socket address, cgroups v2, VSX gallery & Node CA cert env blocks
- `positron.conf` / `vscode.conf` — `session-timeout-kill-hours`, cluster/user-data-dir defaults
- `jupyter.conf` — `session-shutdown-minutes`, culling guidance
- `repos.conf`, `openid-client-secret`, `profiles`, `positron-user-settings.json`, `vscode-user-settings.json`

**Added files** missing locally:
- `audit-database.conf`, `database.conf`, `logging.conf`, `notifications.conf`, `r-versions`, `vscode.extensions.conf`

**Restructured**:
- Migrated `positron-enforced-settings.json` → `positron-enforced-settings/default.json` subfolder to match upstream, updating `profiles` references.

Local-only files not present upstream (`launcher.local.*.conf`, `python.sh`, `workbench-new-defaults/`) were left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)